### PR TITLE
Archive windows binary on main branch and on published releases

### DIFF
--- a/.github/workflows/windows-make.yml
+++ b/.github/workflows/windows-make.yml
@@ -91,4 +91,18 @@ jobs:
       working-directory: Bobcat
       run: |
         ..\upp-source\upp\umk.exe .\,..\upp-source\upp\uppsrc Bobcat CLANG.bm -arb +GUI,WIN64,WIN10 bobcat
+        mkdir out
+        copy Bobcat\Bobcat.exe out\Bobcat.exe
 
+    - name: Build PtyAgent
+      working-directory: Bobcat
+      run: |
+        ..\upp-source\upp\umk.exe ..\upp-source\upp\UppHub\Terminal,..\upp-source\upp\uppsrc PtyAgent CLANG.bm -arb +GUI,WIN64,WIN10 ptyagent
+        cp ptyagent.exe out\PtyAgent.exe
+
+    - name: Archive binaries
+      if: github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: Bobcat-win32
+        path: Bobcat/out/*

--- a/.github/workflows/windows-make.yml
+++ b/.github/workflows/windows-make.yml
@@ -109,12 +109,12 @@ jobs:
       if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v4
       with:
-        name: bobcat-win32
+        name: bobcat-win64
         path: Bobcat/out/*
 
     - name: Push assets into release
       if: github.event_name == 'release' && github.event.action == 'published'
       working-directory: Bobcat
       run: |
-        Compress-Archive -Path out\* -DestinationPath bobcat-${{ github.event.release.tag_name }}-win32.zip
-        gh release upload ${{ github.event.release.tag_name }} bobcat-${{ github.event.release.tag_name }}-win32.zip
+        Compress-Archive -Path out\* -DestinationPath bobcat-${{ github.event.release.tag_name }}-win64.zip
+        gh release upload ${{ github.event.release.tag_name }} bobcat-${{ github.event.release.tag_name }}-win64.zip

--- a/.github/workflows/windows-make.yml
+++ b/.github/workflows/windows-make.yml
@@ -5,11 +5,16 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [ published ]
 
 jobs:
   build:
     runs-on: windows-latest
-    
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
     steps:
     - name: Checkout Bobcat repository
       uses: actions/checkout@v3
@@ -104,5 +109,12 @@ jobs:
       if: github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v4
       with:
-        name: Bobcat-win32
+        name: bobcat-win32
         path: Bobcat/out/*
+
+    - name: Push assets into release
+      if: github.event_name == 'release' && github.event.action == 'published'
+      working-directory: Bobcat
+      run: |
+        Compress-Archive -Path out\* -DestinationPath bobcat-${{ github.event.release.tag_name }}-win32.zip
+        gh release upload ${{ github.event.release.tag_name }} bobcat-${{ github.event.release.tag_name }}-win32.zip


### PR DESCRIPTION
This would enable access to precompiled binaries directly from github actions. Useful for windows users who may not have the stack to compile it locally (this is less true for linux users, and compilation on linux may differ between distributions).